### PR TITLE
The thrust includes need to be after the "namespace cv" since "cv:cuda" creates a conflict 

### DIFF
--- a/Superpixels.h
+++ b/Superpixels.h
@@ -1,4 +1,6 @@
-#pragma once 
+#pragma once
+#include <thrust/system_error.h>
+#include <thrust/system/cuda/error.h>
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 #include <iostream>


### PR DESCRIPTION
These are the changes I made to compile the program with CUDA 12.1, C++11, and using std=c++17