### PR TITLE
The thrust includes need to be after the "namespace cv" since "cv:cuda" creates a conflict

### DIFF
--- a/Superpixels.cpp
+++ b/Superpixels.cpp
@@ -5,8 +5,8 @@
 #include "utils.h"
 
 //#include <ppl.h>
-#include <thrust/system_error.h>
-#include <thrust/system/cuda/error.h>
+//#include <thrust/system_error.h>
+//#include <thrust/system/cuda/error.h>
 #include <iostream>
 #include <fstream>
 

--- a/Superpixels.h
+++ b/Superpixels.h
@@ -1,4 +1,6 @@
 #pragma once 
+#include <thrust/system_error.h>
+#include <thrust/system/cuda/error.h>
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 #include <iostream>


### PR DESCRIPTION
These are the changes I made to compile the program with CUDA 12.1, C++11, and using std=c++17 #19