### PR TITLE
Fix Disconnected Superpixels

### DIFF
--- a/Superpixels.cpp
+++ b/Superpixels.cpp
@@ -5,8 +5,8 @@
 #include "utils.h"
 
 //#include <ppl.h>
-#include <thrust/system_error.h>
-#include <thrust/system/cuda/error.h>
+//#include <thrust/system_error.h>
+//#include <thrust/system/cuda/error.h>
 #include <iostream>
 #include <fstream>
 

--- a/Superpixels.h
+++ b/Superpixels.h
@@ -1,4 +1,6 @@
 #pragma once 
+#include <thrust/system_error.h>
+#include <thrust/system/cuda/error.h>
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 #include <iostream>

--- a/s_m.h
+++ b/s_m.h
@@ -17,7 +17,7 @@ __global__ void calc_hasting_ratio2(const float* image_gpu_double,int* split_mer
 __global__  void merge_sp(int* seg, bool* border, int* split_merge_pairs, superpixel_params* sp_params, superpixel_GPU_helper_sm* sp_gpu_helper_sm, const int nPixels, const int xdim, const int ydim);  
 __global__ void init_sm(const float* image_gpu_double, const int* seg_gpu, superpixel_params* sp_params, superpixel_GPU_helper_sm* sp_gpu_helper_sm, const int nsuperpixel_buffer, const int xdim, int* split_merge_pairs);
 __global__ void remove_sp( int* split_merge_pairs, superpixel_params* sp_params, superpixel_GPU_helper_sm* sp_gpu_helper_sm, const int nsuperpixel_buffer);
-__global__  void calc_split_candidate(int* seg, bool* border,int distance, int* mutex, const int nPixels, const int xdim, const int ydim);
+__global__  void calc_split_candidate(int* dists, int* seg, bool* border,int distance, int* mutex, const int nPixels, const int xdim, const int ydim);
 __global__ void init_split(const bool* border, int* seg_gpu, superpixel_params* sp_params, superpixel_GPU_helper_sm* sp_gpu_helper_sm, const int nsuperpixel_buffer, const int xdim,  const int ydim, const int offset, const int* seg, int* max_sp, int max_SP);
 __host__ int CudaCalcSplitCandidate(const float* image_gpu_double, int* split_merge_pairs, int* seg, bool* border,  superpixel_params* sp_params, superpixel_GPU_helper* sp_gpu_helper, superpixel_GPU_helper_sm* sp_gpu_helper_sm, const int nPixels, const int xdim, const int ydim, const int nSPs_buffer, int* seg_split1, int* seg_split2, int* split3, int max_SP, int count, float i_std, float alpha);
 __global__ void calc_seg_split(int* seg_split1, int* seg_split2,int* seg, int* seg_split3, const int nPixels, int max_SP);


### PR DESCRIPTION
This PR fixes Issue #22 . Running BASS with default settings produces disconnected superpixels on the default images. This PR fixes the problem and has been tested on 50 additional images.

**Reproducing Disconnected Superpixels.** Installing BASS according to the README and executing it on [this image](https://drive.google.com/file/d/1fKO3GsLNeHY20wcU-x7v4Q6QANwcclKa/view?usp=sharing) produces disconnected regions. The superpixel csv file from BASS is [linked here](https://drive.google.com/file/d/1WB064TDcR11SRB4kfP50yFGo3XqkK2h1/view?usp=sharing). The disconnected regions are visualized on [this image](https://drive.google.com/file/d/1F4NRPDbB2Z3FbexxWn4xEj-nPbEckIlg/view?usp=sharing). One of the disconnected superpixel ids is "10" and the disconnection can be verified by printing the superpixels at location [10:20,10:20].

**Changes to Split**. The connectivity issue seems resolved when splits and merges are disabled. So I suspect that the s_m.cu file is the culprit. For splitting, the problem is the `calc_split_candidate` function, where skipping all border pixels will incidentally cut skinny superpixels. So rather than check if a pixel is a border, the code simply checks if the neighbor has the same superpixel. 

**Changes to Merge**. For merging, the problem is the `calc_merge_candidate` function. It uses `W = seg[idx+ydim]`, but should be `W = seg[idx+xdim]`. In `calc_hasting_ratio2`, I did not understand why the merging check uses `k > atomicMax(...)` rather than `0 == atomicMax(...)`. While both versions output no error, merge is only marked once if a zero check is used.